### PR TITLE
Temporary workaround for 'InvalidArgumentException: You must at least ad...

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -9,7 +9,7 @@ class AppKernel extends Kernel
     {
         $bundles = array(
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            //new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,6 +1,6 @@
 imports:
     - { resource: parameters.yml }
-    - { resource: security.yml }
+#    - { resource: security.yml }
     - { resource: services.yml }
 
 framework:


### PR DESCRIPTION
...d one authentication provider'.

InvalidArgumentException in AuthenticationProviderManager.php line 48:
You must at least add one authentication provider.

After removing the AcmeDemo bundle, I get this exception. It is bypassed by disabling the entire security bundle.

Is there a better way to resolve this issue? Or should this merge request be merged?
@fvdb 